### PR TITLE
Move some model & persistence aware code into saveModelNow method

### DIFF
--- a/src/autosaving.coffee
+++ b/src/autosaving.coffee
@@ -48,9 +48,12 @@ Ember.AutoSaving = Ember.Mixin.create
     return unless @get('content.store')
     unless @_isInflight()
       @_flushBuffers()
-      @get('content.store').commit()
+      @_saveModelNow()
     else
       @_debouncedSave()
+
+  _saveModelNow: ->
+    @get('content.store').commit()
 
   _isInflight: ->
     @get('content.isSaving') or @get('content.isLoading')

--- a/src/autosaving.coffee
+++ b/src/autosaving.coffee
@@ -45,7 +45,6 @@ Ember.AutoSaving = Ember.Mixin.create
   # Write the buffers to the actual content and save or
   # try saving again later.
   _safeSave: ->
-    return unless @get('content.store')
     unless @_isInflight()
       @_flushBuffers()
       @_saveModelNow()
@@ -53,6 +52,7 @@ Ember.AutoSaving = Ember.Mixin.create
       @_debouncedSave()
 
   _saveModelNow: ->
+    return unless @get('content.store')
     @get('content.store').commit()
 
   _isInflight: ->


### PR DESCRIPTION
Hey,

This patch allows usage of (at least) ember-restless, as a replacement for ember-data.

It may not work with others, as the code still assumes that certain methods/attributes are existant, but happily for me ember-restless does provide them.

Cheers